### PR TITLE
Make amdh.py executable

### DIFF
--- a/amdh.py
+++ b/amdh.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env -S python
+# -*- coding: utf-8 -*-
+
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime


### PR DESCRIPTION
Instead of having to run `python amdh.py`, this commit allows invoking as such:

```
./amdh.py
```